### PR TITLE
g.sh: zsh support, conditional fixes, ${} var syntax.

### DIFF
--- a/.bashrc.d/g.sh
+++ b/.bashrc.d/g.sh
@@ -1,4 +1,4 @@
-export WORKSPACE="$HOME/Code"
+export WORKSPACE="$HOME/workspace"
 
 # If zsh, load bash autocomplete compat lib.
 if [ -n "$ZSH_VERSION" ]; then

--- a/.bashrc.d/g.sh
+++ b/.bashrc.d/g.sh
@@ -1,39 +1,51 @@
-function _g() {
+export WORKSPACE="$HOME/Code"
+
+# If zsh, load bash autocomplete compat lib.
+if [ -n "$ZSH_VERSION" ]; then
+  autoload bashcompinit
+  bashcompinit
+fi
+
+# Bash Autocompletion Function
+_g() {
   local cur prev opts
+  
   COMPREPLY=()
+
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
-  opts=`ls $HOME/workspace`
+  opts="$(ls ${WORKSPACE})"
 
   COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0
 }
 complete -F _g g
 
-function g {
-    if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+# G project function.
+g() {
+    if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
         echo 'Usage:'
         echo '   g                  cd to primary workspace directory'
         echo '   g <project>        cd to specified project'
         echo '   g <search term>    cd to closest match for search term'
+        
         return
     fi
 
-    if [ -z "$HOME/workspace" ]; then
-        echo 'WARNING: You dont have a $HOME/workspace directory. Running mkdir $HOME/workspace...'
-        mkdir $HOME/workspace
+    if [ -z "$WORKSPACE" ]; then
+        echo 'WARNING: You dont have a ${WORKSPACE} directory. Running mkdir ${WORKSPACE}...'
+        mkdir "${WORKSPACE}"
     fi
 
-    local DIR
+    local DIR="${WORKSPACE}"
     if [ -n "$1" ]; then
-        DIR="$HOME/workspace/$1"
-    else
-        DIR="$HOME/workspace"
+        DIR="${WORKSPACE}/$1"
     fi
 
     if [ -d "$DIR" ]; then
         cd "$DIR"
     else
-        cd $HOME/workspace/`ls $HOME/workspace | grep $1`
+        # HACK multiple results are possible.
+        cd $WORKSPACE/`ls $WORKSPACE | grep $1`
     fi
 }


### PR DESCRIPTION
Adds zsh support by detecting if in zsh, and then loading the bashcomp lib.
Fixes some input logic to use `[[` instead of `[`, which was an issue for me. (different bash versions?)
Uses `${var}` syntax and renames `$HOME/workspace` -> `$WORKSPACE`
Documented the `ls $WORKSPACE | grep $1` as as "hack", since multiple results are possible.

Cool little script, definitely going to be using it!

Notes:
~*$WORKSPACE* is set to `$HOME/Code` right now, forgot to change it back to /workspace~